### PR TITLE
Small modification to reduce_a_hash()

### DIFF
--- a/RainbowTable.py
+++ b/RainbowTable.py
@@ -25,7 +25,7 @@ class RainbowTable:
 
         for i in range(keylength):
             start_index = i * temp_num_chunks
-            one_chunk = a_hash[start_index : start_index + keylength]
+            one_chunk = a_hash[start_index : start_index + temp_num_chunks]
 
             if temp_extra > 0:
                 one_chunk = one_chunk + a_hash[-temp_extra]


### PR DESCRIPTION
reduce_a_hash() was stepping through the hash by steps of 'temp_num_chunks', but then it was only taking 'keysize'-sized chunks to compute an integer. As a result a lot of hex from the hash wasn't being included.